### PR TITLE
Output format of image thumbnail being generated can now be set in description

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ _description_ accepts the following keys:
 * **width** the width of the thumbnail.
 * **height** the height of the thumbnail.
 * **background** background color for matte.
+* **format** what should the output format of the image be, e.g., `jpg`, `gif`, defaults to `jpg`.
 * **strategy** indicate an approach for creating the thumbnail.
   * **matted** maintain aspect ratio, places image on _width x height_ matte.
   * **bounded (default)** maintain aspect ratio, don't place image on matte.

--- a/lib/thumbnailer.js
+++ b/lib/thumbnailer.js
@@ -19,6 +19,7 @@ Thumbnailer.prototype.execute = function(description, localPath, onComplete) {
 		localPath: localPath,
 		width: description.width,
 		height: description.height,
+		format: (description.format || 'jpg'),
 		strategy: (description.strategy || 'bounded'),
 		background: (description.background || 'black'),
 		onComplete: onComplete,
@@ -44,7 +45,7 @@ Thumbnailer.prototype.execute = function(description, localPath, onComplete) {
 Thumbnailer.prototype.createConversionPath = function(callback) {
 	var _this = this;
 
-	tmp.file({dir: this.tmp_dir, postfix: ".jpg"}, function(err, convertedPath, fd) {
+	tmp.file({dir: this.tmp_dir, postfix: "." + this.format}, function(err, convertedPath, fd) {
 		fs.closeSync(fd); // close immediately, we do not use this file handle.
 		_this.convertedPath = convertedPath;
 		callback(err);

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -123,7 +123,7 @@ Worker.prototype._createThumbnails = function(localPath, job, callback) {
 	job.descriptions.forEach(function(description) {
 		work.push(function(done) {
 
-			var remoteImagePath = _this._thumbnailKey(job.original, description.suffix),
+			var remoteImagePath = _this._thumbnailKey(job.original, description.suffix, description.format),
 				thumbnailer = new Thumbnailer({
 					tmp_dir: _this.thumbnailer.tmp_dir,
 					convert_command: _this.thumbnailer.convert_command
@@ -161,11 +161,11 @@ Worker.prototype._saveThumbnailToS3 = function(convertedImagePath, remoteImagePa
 	});
 };
 
-Worker.prototype._thumbnailKey = function(original, suffix) {
+Worker.prototype._thumbnailKey = function(original, suffix, format) {
 	var extension = original.split('.').pop(),
 		prefix = original.split('.').slice(0, -1).join('.');
 
-	return prefix + '_' + suffix + '.jpg';
+	return prefix + '_' + suffix + '.' + (format || 'jpg');
 };
 
 Worker.prototype._deleteJob = function(handle) {


### PR DESCRIPTION
You can now set the output format of the image being generated, by setting the format flag in a thumbnail description.
