### PR TITLE
Add quality key to description

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ _description_ accepts the following keys:
   * **matted** maintain aspect ratio, places image on _width x height_ matte.
   * **bounded (default)** maintain aspect ratio, don't place image on matte.
   * **fill** both resizes and zooms into an image, filling the specified dimensions.
+* **quality** the quality of the thumbnail, in percent. e.g. `90`.
 
 CLI
 ---

--- a/lib/thumbnailer.js
+++ b/lib/thumbnailer.js
@@ -57,14 +57,14 @@ Thumbnailer.prototype.execCommand = function(command) {
 	var _this = this;
 
 	exec(command, {timeout: this.thumbnailTimeout}, function(err, stdout, stderr) {
-
+		
 		console.log('running command ', command);
 
 		if (err) {
 			_this.onComplete(err);
 			return;
 		}
-
+		
 		// make sure the conversion was successful.
 		fs.stat(_this.convertedPath, function(err, stat) {
 			err = err || stat.size === 0 ? 'zero byte thumbnail created' : null;
@@ -83,7 +83,7 @@ exports.Thumbnailer = Thumbnailer;
 Thumbnailer.prototype.matted = function() {
 	var qualityString = (this.quality ? '-quality ' + this.quality : ''),
 		thumbnailCommand = this.convert_command + ' "' + this.localPath + '[0]" -thumbnail ' + (this.width * this.height) + '@ -gravity center -background ' + this.background + ' -extent ' + this.width + 'X' + this.height + ' ' + qualityString + ' ' + this.convertedPath;
-
+	
 	this.execCommand(thumbnailCommand);
 };
 
@@ -98,7 +98,7 @@ Thumbnailer.prototype.bounded = function() {
 Thumbnailer.prototype.fill = function() {
 	var dimensionsString = this.width + 'X' + this.height,
 		qualityString = (this.quality ? '-quality ' + this.quality : ''),
-		thumbnailCommand = this.convert_command + ' "' + this.localPath + '[0]" -resize ' + dimensionsString + '^ -gravity center -extent ' + dimensionsString + ' ' + qualityString + ' ' + this.convertedPath;
+				thumbnailCommand = this.convert_command + ' "' + this.localPath + '[0]" -resize ' + dimensionsString + '^ -gravity center -extent ' + dimensionsString + ' ' + qualityString + ' ' + this.convertedPath;
 
 	this.execCommand(thumbnailCommand);
 }


### PR DESCRIPTION
This PR adds the ability for a client to set the quality of individual thumbnails to a higher or lower value, allowing an individual thumbnail to have a smaller file size at the cost of image quality, making the image a faster download. This feature can be important for image heavy pages.

The quality of the thumbnails being generated are [automatically determined](http://www.imagemagick.org/script/command-line-options.php#quality) by default. 

In my tests, resizing a large JPG photo at a quality of `90` can result in a file size reduction of almost 2x over the default quality setting, making it download almost 2x faster.
