### PR TITLE
Switch to AWS Node.js SDK

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1,22 +1,25 @@
-var aws = require('aws-lib'),
+var aws = require('aws-sdk'),
   _ = require('underscore'),
   Saver = require('./saver').Saver;
-  
+
 function Client(opts) {
   _.extend(this, {
     awsKey: process.env.AWS_KEY,
     awsSecret: process.env.AWS_SECRET,
+    awsRegion: process.env.AWS_REGION || "us-east-1",
     sqsQueue: process.env.SQS_QUEUE, // Queue to listen for thumbnail jobs on.
     s3Bucket: process.env.BUCKET // S3 Bucket to perform thumbnailing within.
   }, opts);
 
   // Create an SQS client for
   // submitting thumbnailing work.
-  this.sqs = aws.createSQSClient(
-    this.awsKey,
-    this.awsSecret,
-    {'path': this.sqsQueue}
-  );
+  this.sqs = new aws.SQS({
+    accessKeyId: this.awsKey,
+    secretAccessKey: this.awsSecret,
+    region: this.awsRegion
+  });
+
+  this.sqsQueueUrl = this.sqs.endpoint.protocol + '//' + this.sqs.endpoint.hostname + '/' + this.sqsQueue;
 }
 
 /**
@@ -64,7 +67,7 @@ Client.prototype.thumbnail = function(originalImagePath, thumbnailDescriptions, 
       }],
     }
   */
-  this.sqs.call ( "SendMessage", {MessageBody: JSON.stringify({
+  this.sqs.sendMessage({QueueUrl: this.sqsQueueUrl, MessageBody: JSON.stringify({
     original: originalImagePath,
     descriptions: thumbnailDescriptions
   })}, function (err, result) {

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -1,4 +1,4 @@
-var aws = require('aws-lib'),
+var aws = require('aws-sdk'),
 	_ = require('underscore'),
 	Grabber = require('./grabber').Grabber,
 	Thumbnailer = require('./thumbnailer').Thumbnailer,
@@ -13,14 +13,17 @@ function Worker(opts) {
 		saver: null,
 		aws_key: process.env.AWS_KEY,
 		aws_secret: process.env.AWS_SECRET,
+		aws_region: process.env.AWS_REGION || "us-east-1",
 		sqs_queue: process.env.SQS_QUEUE
 	}, opts);
 
-	this.sqs = aws.createSQSClient(
-		this.aws_key,
-		this.aws_secret,
-		{'path': this.sqs_queue}
-	);
+    this.sqs = new aws.SQS({
+        accessKeyId: this.aws_key,
+        secretAccessKey: this.aws_secret,
+        region: this.aws_region
+    });
+
+    this.sqs_queue_url = this.sqs.endpoint.protocol + '//' + this.sqs.endpoint.hostname + '/' + this.sqs_queue;
 }
 
 Worker.prototype.start = function() {
@@ -30,33 +33,30 @@ Worker.prototype.start = function() {
 Worker.prototype._processSQSMessage = function() {
 	var _this = this;
 
-	console.log('wait for message on ' + _this.sqs_queue)
+	console.log('wait for message on ' + _this.sqs_queue);
 
-	this.sqs.call ( "ReceiveMessage", {}, function (err, job) {
-
-		err = err || job.Error;
-		
+	this.sqs.receiveMessage( { QueueUrl: this.sqs_queue_url, MaxNumberOfMessages: 1 }, function (err, job) {
 		if (err) {
 			console.log(err);
 			_this._processSQSMessage();
 			return;
 		}
 
-		if (!job.ReceiveMessageResult.Message) {
+		if (!job.Messages || job.Messages.length == 0) {
 			_this._processSQSMessage();
 			return;
 		}
 
 		// Handle the message we pulled off the queue.
-		var handle = job.ReceiveMessageResult.Message.ReceiptHandle,
+		var handle = job.Messages[0].ReceiptHandle,
 			body = null;
 
 		try { // a JSON string message body is accepted.
-			body = JSON.parse( job.ReceiveMessageResult.Message.Body );
+			body = JSON.parse( job.Messages[0].Body );
 		} catch(e) {
 			if (e instanceof SyntaxError) {
 				// a Base64 encoded JSON string message body is also accepted.
-				body = JSON.parse( new Buffer(job.ReceiveMessageResult.Message.Body, 'base64').toString( 'binary' ) );
+				body = JSON.parse( new Buffer(job.Messages[0].Body, 'base64').toString( 'binary' ) );
 			} else {
 				throw e;
 			}
@@ -140,7 +140,7 @@ Worker.prototype._createThumbnails = function(localPath, job, callback) {
 						done();
 					});
 				}
-				
+
 			});
 
 		});
@@ -169,7 +169,7 @@ Worker.prototype._thumbnailKey = function(original, suffix, format) {
 };
 
 Worker.prototype._deleteJob = function(handle) {
-	this.sqs.call("DeleteMessage", {ReceiptHandle: handle}, function(err, resp) {	
+	this.sqs.deleteMessage({QueueUrl: this.sqs_queue_url, ReceiptHandle: handle}, function(err, resp) {
 		console.log('deleted thumbnail job ' + handle);
 	});
 };

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 	},
 	"dependencies": {
 		"knox": ">=0.8.0",
-		"aws-lib": ">=0.2.1",
+		"aws-sdk": ">=1.7.1",
 		"underscore": ">=1.4.2",
 		"tmp": ">=0.0.16",
 		"optimist": "0.3.4",


### PR DESCRIPTION
This PR changes our AWS library from [aws-lib](https://github.com/livelycode/aws-lib) to Amazon's [aws-sdk-js](https://github.com/aws/aws-sdk-js).

The reason for the switch is to fix an issue I've been having recently, where thumbd has been throwing several of these errors per second:

```
2013-10-08T15:07:18.623362+00:00 wait for message on 1234567890/foo-bar-baz
2013-10-08T15:07:18.670014+00:00 { [Error: Parse Error] bytesParsed: 0, code: 'HPE_INVALID_CONSTANT' }
```

Apparently, the `HPE_INVALID_CONSTANT` error is being thrown because `the remote server responds with
a Content-Length header, but  proceeds to send you content longer than that`. See [this post](http://grokbase.com/t/gg/nodejs/136mx1hjz7/fun-little-http-bug) for more details. This points to an issue on AWS' side of things, making it difficult to fix in thumbd or aws-lib. Therefore, I figured switching to the AWS SDK would likely be the easiest solution.

Another benefit of switching to aws-sdk-js is that it appears to be updated more often than aws-lib. The downside is that aws-sdk-js requires one more configuration setting (AWS region), and a slightly more complex implementation.
