### PR TITLE
Pulled in Mocha for Testing and Sinon for Mocks/Stubs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+test:
+	@./node_modules/.bin/mocha -u bdd -R nyan
+
+.PHONY: test

--- a/lib/thumbnailer.js
+++ b/lib/thumbnailer.js
@@ -1,13 +1,17 @@
 var exec = require('child_process').exec,
 	_ = require('underscore'),
-	tmp = require('tmp'),
 	fs = require('fs'),
 	config = require('./config').Config;
 
 /**
  * Initialize the Thumbnailer
  */
-function Thumbnailer() {
+function Thumbnailer(opts) {
+	// for the benefit of testing
+	// perform dependency injection.
+	_.extend(this, {
+		tmp: require('tmp')
+	}, opts);
 }
 
 /**
@@ -58,7 +62,7 @@ Thumbnailer.prototype.execute = function(description, localPath, onComplete) {
 Thumbnailer.prototype.createConversionPath = function(callback) {
 	var _this = this;
 
-	tmp.file({dir: config.get('tmpDir'), postfix: "." + this.format}, function(err, convertedPath, fd) {
+	this.tmp.file({dir: config.get('tmpDir'), postfix: "." + this.format}, function(err, convertedPath, fd) {
 		fs.closeSync(fd); // close immediately, we do not use this file handle.
 		_this.convertedPath = convertedPath;
 		callback(err);
@@ -110,8 +114,8 @@ Thumbnailer.prototype.matted = function() {
  */
 Thumbnailer.prototype.bounded = function() {
 	var dimensionsString = this.width + 'X' + this.height,
-		qualityString = (this.quality ? '-quality ' + this.quality : ''),
-		thumbnailCommand = config.get('convertCommand') + ' "' + this.localPath + '[0]" -thumbnail ' + dimensionsString + ' ' + qualityString + ' ' + this.convertedPath;
+		qualityString = (this.quality ? '-quality ' + this.quality + ' ' : ''),
+		thumbnailCommand = config.get('convertCommand') + ' "' + this.localPath + '[0]" -thumbnail ' + dimensionsString + ' ' + qualityString + this.convertedPath;
 
 	this.execCommand(thumbnailCommand);
 };

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
 	"engines": [
 		"node"
 	],
+  "scripts": {
+    "test": "make test"
+  },
 	"description": "Node.js/AWS/ImageMagick-based image thumbnailing service.",
 	"keywords": [
 		"image",
@@ -31,5 +34,9 @@
 		"tmp": ">=0.0.16",
 		"optimist": "0.3.4",
 		"async": ">=0.2.7"
+	},
+	"devDependencies": {
+    "mocha": ">=1.7.4",
+    "sinon": ">=1.6.0"
 	}
 }

--- a/test/test-config.js
+++ b/test/test-config.js
@@ -1,0 +1,13 @@
+var assert = require('assert');
+
+describe('#Config', function() {
+  it("should keep settings if config required multiple times", function() {
+    var Config = require('../lib/config').Config;
+
+    Config.set('awsKey', 'abc123');
+
+    Config = require('../lib/config').Config;
+
+    assert.equal(Config.get('awsKey'), 'abc123');
+  });
+});

--- a/test/test-thumbnailer.js
+++ b/test/test-thumbnailer.js
@@ -1,0 +1,98 @@
+var assert = require('assert'),
+  sinon = require('sinon'),
+  Thumbnailer = require('../lib/thumbnailer').Thumbnailer;
+
+describe("#Thumbnailer", function() {
+
+  describe("#createConversionPath", function() {
+
+    it("tmp.file() executed with appropriate parameters", function() {
+      // we mock tmp.file() which is called
+      // during the thumbnailer's execute phase.
+      var tmp = {file: function() {}},
+        mock = sinon.mock(tmp)
+          .expects('file')
+          .once()
+          .withArgs({dir: '/tmp', postfix: '.png'}),
+        thumbnailer = new Thumbnailer({tmp: tmp});
+
+      // execute the thumbnailer with
+      // our mock tmp.
+      thumbnailer.execute({
+        format: 'png'
+      });
+
+      // assert the expectations outlined
+      // while creating the mock.
+      mock.verify();
+    });
+
+  });
+
+  describe('#execCommand', function() {
+    
+    beforeEach(function() {
+      // create a thumbnailer with some of the
+      // internals stubbed out.
+      this.thumbnailer = new Thumbnailer();
+      this.thumbnailer.convertedPath = '/tmp/222.jpg'
+
+      // Simply execute callback when createConversionPath
+      // is called.
+      sinon.stub(this.thumbnailer, 'createConversionPath')
+        .callsArg(0);
+    });
+
+    afterEach(function() {
+      // Restore sinon's mocks.
+      this.thumbnailer.execCommand.restore();
+    });
+
+    describe('#bounded', function() {
+
+      it('appropriate convert command generated if no quality set', function() {
+        var convertCommand = 'convert "/tmp/111.png[0]" -thumbnail 96X96 /tmp/222.jpg';
+
+        // We don't actually want to execute the
+        // convert command.
+        var mock = sinon.mock(this.thumbnailer)
+          .expects('execCommand')
+          .once()
+          .withArgs(convertCommand);
+
+        this.thumbnailer.execute({
+          width: 96,
+          height: 96,
+          format: 'png',
+          strategy: 'bounded'
+        }, '/tmp/111.png');
+
+        mock.verify();
+      });
+
+      it('appropriate convert command generated if quality set', function() {
+        var convertCommand = 'convert "/tmp/111.png[0]" -thumbnail 96X96 -quality 75 /tmp/222.jpg';
+
+        // We don't actually want to execute the
+        // convert command.
+        var mock = sinon.mock(this.thumbnailer)
+          .expects('execCommand')
+          .once()
+          .withArgs(convertCommand);
+
+        this.thumbnailer.execute({
+          quality: 75,
+          width: 96,
+          height: 96,
+          format: 'png',
+          strategy: 'bounded'
+        }, '/tmp/111.png');
+
+        mock.verify();
+      });
+
+    });
+
+  });
+
+});


### PR DESCRIPTION
I'm finally correcting my past mistakes, and starting to build out some tests around thumbd.

I've pulled in Mocha for testing:

http://visionmedia.github.io/mocha/

And Sinon, which is a great library for mocks:

http://sinonjs.org/

I tend to advocate a TDD approach to development now; Going forward it would be nice to:
- Retroactively get tests around key parts of thumbd.
- Make sure to write tests around any new functionality that we build out.
