### PR TITLE
Add continuous integration via Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - "0.11"
+  - "0.10"
+  - "0.8"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Thumbd
 ======
 
+Build Status: [![Build Status](https://travis-ci.org/bcoe/thumbd.png)](https://travis-ci.org/bcoe/thumbd)
+
 Thumbd is an image thumbnailing server built on top of Node.js, SQS, S3, and ImageMagick.
 
 Setup


### PR DESCRIPTION
Now that we have some unit tests, it seems like a perfect time to add continuous integration.

Travis CI is a great service for open source projects, and offers excellent [Node.js unit testing](http://about.travis-ci.org/docs/user/languages/javascript-with-nodejs/).

Travis allows us to put a nifty [build status badge](http://about.travis-ci.org/docs/user/status-images/) in our Readme so that anyone visiting the repo page in Github immediately knows the build status of the master branch.

By default, all branches will be [built when pushed up](http://about.travis-ci.org/docs/user/build-configuration/#Specify-branches-to-build), and [notifications](http://about.travis-ci.org/docs/user/notifications/#Notifications) will be sent out regarding the build status of each branch.

@bcoe Since you're the repo owner, you'll need to [setup Travis CI](http://about.travis-ci.org/docs/user/getting-started/#Step-one%3A-Sign-in) before it'll work for this repo. Note that Step 3 has already been done, and is a part of this PR.
