### PR TITLE
Knox wants AWS region us-standard instead of us-east-1 

### DIFF
--- a/bin/thumbd.js
+++ b/bin/thumbd.js
@@ -61,9 +61,9 @@ switch (mode) {
 			bucket: config.get('s3Bucket')
 		}
 
-		// Don't add the region if it's US Standard (us-east-1), otherwise we get 404's
-		if (config.get('awsRegion') != 'us-east-1') {
-			knoxOpts.region = config.get('awsRegion');
+		// Knox wants 'us-standard' instead of 'us-east-1'
+		if (config.get('awsRegion') == 'us-east-1') {
+			knoxOpts.region = 'us-standard';
 		}
 
 		var s3 = knox.createClient(knoxOpts);


### PR DESCRIPTION
Knox follows a (AFAIK) non-standard region naming for the US Standard (us-east-1) region, where instead of `us-east-1`, it expects `us-standard`.

Leaving the AWS region as `us-east-1` causes requests to S3 to 404.

This PR modifies the knox config so that if the `AWS_REGION` setting is `us-east-1`, we translate it to `us-standard` just for knox.
