### PR TITLE
Don't encode uri's for knox

### DIFF
--- a/lib/grabber.js
+++ b/lib/grabber.js
@@ -102,7 +102,7 @@ Grabber.prototype.getFileHTTP = function(remoteImagePath, localImagePath, stream
  */
 Grabber.prototype.getFileS3 = function(remoteImagePath, localImagePath, stream, callback) {
 	var _this = this,
-		req = this.s3.getFile(encodeURI(remoteImagePath), function(err, res) {
+		req = this.s3.getFile(remoteImagePath, function(err, res) {
 
 			if (err || res.statusCode >= 400) {
 				err = 'error retrieving from S3 status ' + res.statusCode;

--- a/lib/saver.js
+++ b/lib/saver.js
@@ -37,7 +37,7 @@ Saver.prototype.save = function(source, destination, callback) {
 		destination = this.destinationFromURL(destination);
 	}
 
-	this.s3.putFile(source, encodeURI(destination), headers, function(err, res) {
+	this.s3.putFile(source, destination, headers, function(err, res) {
 		if (err) {
 			if (callback) callback(err);
 		} else {


### PR DESCRIPTION
Knox now encodes URI's by default, meaning that if thumbd also encodes those URI's before sending them to knox, we get issues when files have spaces or special characters in them.

E.g.
- I upload `file name.jpg` to S3
- I notify the thumbd SQS queue
- Thumbd pulls down the JSON blob from SQS containing the original filename
- Thumbd encodes the original filename as `file%20name.jpg`
- Knox encodes the filename from thumbd as `file%2520name.jpg`
- The knox request to S3 for the file fails, as `file%2520name.jpg` doesn't exist.
