### PR TITLE
Support long polling, save a lot of cost on AWS

### DIFF
--- a/bin/thumbd.js
+++ b/bin/thumbd.js
@@ -16,7 +16,8 @@ var thumbd = require('../lib'),
 		s3_acl: 's3Acl',
 		s3_storage_class: 's3StorageClass',
 		sqs_queue: 'sqsQueue',
-		tmp_dir: 'tmpDir'
+		tmp_dir: 'tmpDir',
+		wait_time: 'waitTime'
 	},
 	thumbnailOpts = {
 		aws_key: 'awsKey',

--- a/lib/config.js
+++ b/lib/config.js
@@ -11,7 +11,8 @@ exports.Config = {
 		s3Bucket: process.env.BUCKET,
 		s3StorageClass: (process.env.S3_STORAGE_CLASS || 'STANDARD'),
 		sqsQueue: process.env.SQS_QUEUE,
-		tmpDir: (process.env.TMP_DIR || '/tmp')
+		tmpDir: (process.env.TMP_DIR || '/tmp'),
+		waitTime: (process.env.WAIT_TIME || 1)
 	},
 
 	/**

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -43,7 +43,7 @@ Worker.prototype._processSQSMessage = function() {
 
 	console.log('wait for message on ' + config.get('sqsQueue'));
 
-	this.sqs.receiveMessage( { QueueUrl: config.get('sqsQueueUrl'), MaxNumberOfMessages: 1 }, function (err, job) {
+	this.sqs.receiveMessage( { QueueUrl: config.get('sqsQueueUrl'), MaxNumberOfMessages: 1, WaitTimeSeconds: config.get('waitTime') }, function (err, job) {
 		if (err) {
 			console.log(err);
 			_this._processSQSMessage();


### PR DESCRIPTION
thumbd server was not using Long Polling due to which it was
requesting SQS every 76ms (on my server). This means that each
day it was making over a million requests. Which is a lot of
cost. About $0.5 a day for each instance of thumbd.
Now you can specify --wait_time=N where N is seconds from 1 to 20
and it'll long poll thus saving the number of requests by a great factor.
