### PR TITLE
config needs to be updated by the parameters passed in

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -9,6 +9,7 @@ var aws = require('aws-sdk'),
  * @param object opts The Client options
  */
 function Client(opts) {
+	config.extend(opts);
 
 	// allow sqs to be overridden
 	// in tests.
@@ -22,8 +23,6 @@ function Client(opts) {
 			region: config.get('awsRegion')
 		});
 	}
-
-	config.extend(opts);
 
 	config.set('sqsQueueUrl', this.sqs.endpoint.protocol + '//' + this.sqs.endpoint.hostname + '/' + config.get('sqsQueue'));
 }


### PR DESCRIPTION
Hi,

A recent change for overriding sqs moved the "config.extend" to after "config.get" which results in null config values.
{"accessKeyId":null,"secretAccessKey":null,"region":"us-east-1"}

Moving the config.extend to beginning of the method resolves the issue.

Thanks,
Ali 
