### PR TITLE
if no callback provided to save, then create a noop function

### DIFF
--- a/lib/saver.js
+++ b/lib/saver.js
@@ -29,6 +29,10 @@ function Saver(s3) {
  * @param function callback The callback function. Optional
  */
 Saver.prototype.save = function(source, destination, callback) {
+	if (typeof callback === 'undefined') {
+		callback = function(){};
+	}
+
 	var headers = {
 		'x-amz-acl': config.get('s3Acl'),
 		'x-amz-storage-class': config.get('s3StorageClass')


### PR DESCRIPTION
I forgot that the callback to save was optional.
