### PR TITLE
Ensure the error from failed thumbnailing jobs propagate

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -117,6 +117,9 @@ Worker.prototype._runJob = function(handle, job, callback) {
 		function(localPaths, done) {
 			_this._createThumbnails(localPaths, job, function(err, uploadedFiles) {
 				async.forEach(localPaths, fs.unlink, function(errUnlink) {
+					if (errUnlink) {
+						console.log("WARNING: failed to delete temporary file " + errUnlink.path);
+					}
 					done(err, uploadedFiles);
 				});
 			});


### PR DESCRIPTION
The error from creating a thumbnail isn't currently propagated. We could either propagate this error instead of a possible file unlink error or take both errors into consideration. I personally do not think we should fail a job if a file unlink fails, so we could just ignore it. What do you think @bcoe?
