### PR TITLE
Fixed issue for strict strategy where localPaths[0] was misdefined

### DIFF
--- a/lib/thumbnailer.js
+++ b/lib/thumbnailer.js
@@ -183,7 +183,7 @@ Thumbnailer.prototype.fill = function() {
 Thumbnailer.prototype.strict = function() {
 	var dimensionsString = this.width + 'X' + this.height,
 		qualityString = (this.quality ? '-quality ' + this.quality : ''),
-		thumbnailCommand = config.get('convertCommand') + ' "' + this.localPath + '[0]" -resize ' + dimensionsString + '! ' + qualityString + ' ' + this.convertedPath;
+		thumbnailCommand = config.get('convertCommand') + ' "' + this.localPaths[0] + '[0]" -resize ' + dimensionsString + '! ' + qualityString + ' ' + this.convertedPath;
 
 	this.execCommand(thumbnailCommand);
 };


### PR DESCRIPTION
Fixed issue for strict strategy where localPaths[0] was misdefined as localPath causing failure of image convertion using this stategy.
