### PR TITLE
Fixed matted so it doesn't crop images

### DIFF
--- a/lib/thumbnailer.js
+++ b/lib/thumbnailer.js
@@ -149,8 +149,9 @@ Thumbnailer.prototype.manual = function() {
  * Convert the image using the matted strategy
  */
 Thumbnailer.prototype.matted = function() {
-	var qualityString = (this.quality ? '-quality ' + this.quality : ''),
-		thumbnailCommand = config.get('convertCommand') + ' "' + this.localPaths[0] + '[0]" -thumbnail ' + (this.width * this.height) + '@ -gravity center -background ' + this.background + ' -extent ' + this.width + 'X' + this.height + ' ' + qualityString + ' ' + this.convertedPath;
+	var dimensionsString = this.width + 'X' + this.height,
+	  qualityString = (this.quality ? '-quality ' + this.quality : ''),
+		thumbnailCommand = config.get('convertCommand') + ' "' + this.localPaths[0] + '[0]" -resize ' + dimensionsString + ' -size ' + dimensionsString + ' xc:' + this.background + ' +swap -gravity center' + qualityString + ' -composite ' + this.convertedPath;
 
 	this.execCommand(thumbnailCommand);
 };


### PR DESCRIPTION
Fixed matted so it doesn't crop images, espacially an issue with very tall images in portrait orientation.

Issue reference #46
