### PR TITLE
Multi bucket support

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -105,8 +105,6 @@ Worker.prototype._runJob = function(handle, job, callback) {
 		}
 	*/
 
-	var bucket = job.bucket;
-
 	// handle legacy, 'original' key vs. 'resources'.
 	if (job.original) job.resources = [job.original];
 
@@ -115,7 +113,7 @@ Worker.prototype._runJob = function(handle, job, callback) {
 	async.waterfall([
 		function(done) {
 			async.mapLimit(job.resources, 5, function(resource, done) {
-				_this._downloadFromS3(resource, done);
+				_this._downloadFromS3(job.bucket, resource, done);
 			}, done);
 		},
 		function(localPaths, done) {
@@ -185,7 +183,7 @@ Worker.prototype._createThumbnails = function(localPaths, job, callback) {
 					console.log(err);
 					done();
 				} else {
-					_this._saveThumbnailToS3(bucket, convertedImagePath, remoteImagePath, function(err) {
+					_this._saveThumbnailToS3(job.bucket, convertedImagePath, remoteImagePath, function(err) {
 						if (err) console.log(err);
 						done(null, remoteImagePath);
 					});


### PR DESCRIPTION
This adds the feature to optionally specify bucket name with a job. See #54

If a bucket name is specified with a job, worker will create a s3 client to work with new bucket and it will then be passed to other worker modules (e.g. grabber, saver etc)

Tested on Heroku to be working fine.
