### PR TITLE
fix for us-west-2

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -13,7 +13,9 @@ exports.Config = {
 		sqsQueue: process.env.SQS_QUEUE,
 		tmpDir: (process.env.TMP_DIR || '/tmp'),
 		logLevel: (process.env.LOG_LEVEL || 'info'),
-		profile: !!process.env.PROFILE
+		profile: !!process.env.PROFILE,
+		metaPrefix:(process.env.META_PREFIX || 'x-amz-meta-'),
+		keepMeta:(process.env.META || true)
 	},
 
 	/**

--- a/lib/grabber.js
+++ b/lib/grabber.js
@@ -108,8 +108,17 @@ Grabber.prototype.getFileS3 = function(bucket, region, remoteImagePath, localIma
 			});
 
 			res.on('end', function() {
+				var metadata={};
+				//keep custom headers/metadata
+				if (config.config.keepMeta){
+					for (prop in res.headers){
+						if (prop.slice(0,11)==config.config.metaPrefix){
+							metadata[prop]=res.headers[prop];
+						}
+					}					
+				}
 				stream.end();
-				callback(null, localImagePath);
+				callback(null, localImagePath,metadata);
 			});
 
 		}).on('socket', function(socket) {  // abort connection if we're in idle state too long.

--- a/lib/saver.js
+++ b/lib/saver.js
@@ -18,9 +18,8 @@ function Saver() {
  * @param string destination The local file path
  * @param function callback The callback function. Optional
  */
-Saver.prototype.save = function(bucket, region, source, destination, callback) {
+Saver.prototype.save = function(bucket, region, source, destination,metadata, callback) {
 	var _this = this;
-
 	if (typeof callback === 'undefined') {
 		callback = function(){};
 	}
@@ -29,18 +28,20 @@ Saver.prototype.save = function(bucket, region, source, destination, callback) {
 		'x-amz-acl': config.get('s3Acl'),
 		'x-amz-storage-class': config.get('s3StorageClass')
 	};
+	//get custom headers if any
+	for (prop in metadata){
+		headers[prop]=metadata[prop];
+	}
 
 	if (destination.match(/https?:\/\//)) {
 		destination = this.destinationFromURL(destination);
-	}
-
+	}	
 	utils.s3(bucket, region).putFile(source, destination, headers, function(err, res) {
 
 		// if the region or bucket is wrong, this is reflected in a 301.
 		if (res && res.statusCode !== 200) {
 			return callback(Error('upload failure status = ' + res.statusCode));
 		}
-
 		if (err) return callback(err);
 
 		res.on('error', function(err) {

--- a/lib/thumbnailer.js
+++ b/lib/thumbnailer.js
@@ -25,7 +25,7 @@ function Thumbnailer(opts) {
  */
 Thumbnailer.prototype.execute = function(description, localPaths, onComplete) {
 	var _this = this;
-
+	
 	// Convert single path to array
 	if (!_.isArray(localPaths)) {
 		localPaths = [localPaths];

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -12,7 +12,7 @@ exports.s3 = function(_bucket, _region) {
     region = _region || config.get('awsRegion');
 
   // Knox wants 'us-standard' instead of 'us-east-1'.
-	if (region == 'us-east-1') region = 'us-standard';
+	if (region == 'us-east-1'|| region=='us-west-2') region = 'us-standard';
 
   // cache the most recently used client.
   if (client && bucket === client.bucket && region === client.region) {

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -127,8 +127,13 @@ Worker.prototype._runJob = function(handle, job, callback) {
 				_this._downloadFromS3(job.bucket, job.region, resource, done);
 			}, done);
 		},
-		function(localPaths, done) {
-			_this._createThumbnails(localPaths, job, function(err, uploadedFiles) {
+		function(localObject, done) {
+			_this._createThumbnails(localObject, job, function(err, uploadedFiles) {
+				//get paths from local object
+				var localPaths=[];
+				for (var i=0;i<localObject.length;i++){
+					localPaths.push(localObject[i].localPath);
+				}
 				async.forEach(localPaths, fs.unlink, function(errUnlink) {
 					if (errUnlink) {
 						_this.logger.warn("WARNING: failed to delete temporary file " + errUnlink.path);
@@ -159,14 +164,13 @@ Worker.prototype._downloadFromS3 = function(bucket, region, remoteImagePath, cal
 	var bucket = bucket || config.get('s3Bucket'),
 		region = region || config.get('awsRegion');
 
-	this.grabber.download(bucket, region, remoteImagePath, function(err, localPath) {
+	this.grabber.download(bucket, region, remoteImagePath, function(err, localPath,metadata) {
 		// Leave the job in the queue if an error occurs.
 		if (err) {
 			callback(err);
 			return;
 		}
-
-		callback(null, localPath);
+		callback(null, {localPath:localPath,metadata:metadata});
 	});
 };
 
@@ -177,12 +181,19 @@ Worker.prototype._downloadFromS3 = function(bucket, region, remoteImagePath, cal
  * @param object job The job description
  * @param function callback The callback function
  */
-Worker.prototype._createThumbnails = function(localPaths, job, callback) {
+Worker.prototype._createThumbnails = function(localObject, job, callback) {
 
 	var _this = this,
 		work = [],
 		bucket = job.bucket || config.get('s3Bucket'),
 		region = job.region || config.get('awsRegion');
+
+
+	//get paths from local object
+	var localPaths=[];
+	for (var i=0;i<localObject.length;i++){
+		localPaths.push(localObject[i].localPath);
+	}
 
 	// Create thumbnailing work for each thumbnail description.
 	job.descriptions.forEach(function(description) {
@@ -197,7 +208,7 @@ Worker.prototype._createThumbnails = function(localPaths, job, callback) {
 					_this.logger.error(err);
 					done();
 				} else {
-					_this._saveThumbnailToS3(bucket, region, convertedImagePath, remoteImagePath, function(err) {
+					_this._saveThumbnailToS3(bucket, region, convertedImagePath, remoteImagePath,localObject[0].metadata, function(err) {
 						if (err) _this.logger.error(err);
 						done(null, remoteImagePath);
 					});
@@ -219,8 +230,8 @@ Worker.prototype._createThumbnails = function(localPaths, job, callback) {
  * @param string remoteImagePath The S3 path for the image
  * @param function callback The callback function
  */
-Worker.prototype._saveThumbnailToS3 = function(bucket, region, convertedImagePath, remoteImagePath, callback) {
-	this.saver.save(bucket, region, convertedImagePath, remoteImagePath, function(err) {
+Worker.prototype._saveThumbnailToS3 = function(bucket, region, convertedImagePath, remoteImagePath,metadata, callback) {
+	this.saver.save(bucket, region, convertedImagePath, remoteImagePath,metadata, function(err) {
 		fs.unlink(convertedImagePath, function() {
 			callback(err);
 		});


### PR DESCRIPTION
Fix for the `us-west-2` region, similar to the fix for the `us-east-1` on the same line of code. Without this, S3 throws a 301 error. [See this issue](https://github.com/bcoe/thumbd/issues/80).