### PR TITLE
Support signature version 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ You can easily run Thumbd on *Heroku*. Simply set the appropriate environment va
 
 Note: Creating video thumbnails on Heroku requires use of custom [ffmpeg](https://github.com/shunjikonishi/heroku-buildpack-ffmpeg) buildpack. Please refer to [Heroku deployment guide](https://github.com/bcoe/thumbd/wiki/Running-Thumbd-on-Heroku) in Wiki.
 
+MODIFY
+-----
+* Support SignatureVersion V4
+* Support Region of China
+* Replace Knox by AWS SDK
+* Can't connect to S3 by HTTP Now !!!
+
+
 Setup
 -----
 

--- a/lib/grabber.js
+++ b/lib/grabber.js
@@ -25,26 +25,28 @@ Grabber.prototype.download = function(bucket, region, remoteImagePath, callback)
 		extension = "."+remoteImagePath.split('.').pop();
 
 	
-	tmp.file({dir: config.get('tmpDir'), postfix: ""}, function(err, localImagePath, fd) {
+	tmp.file({dir: config.get('tmpDir'), postfix: extension}, function(err, localImagePath, fd) {
 		//_this.logger.info('downloading', remoteImagePath, 'from s3 to local file', localImagePath);
 		if (err) return callback(err);
 		//var stream = fs.createWriteStream(localImagePath, { flags: 'w', encoding: null, mode: 0666 });
-		var stream = null;
-		_this.getFileS3(bucket, region, remoteImagePath, localImagePath, stream,extension, callback);
-		/*
+		//var stream = null;
+		//_this.getFileS3(bucket, region, remoteImagePath, localImagePath, stream,extension, callback);
+		
 		fs.close(fd, function() {
 			_this.logger.info('downloading', remoteImagePath, 'from s3 to local file', localImagePath);
 
 			var stream = fs.createWriteStream(localImagePath);
 			//var stream = null;
-
+			/*
 			if (remoteImagePath.match(/https?:\/\//)) { // we are thumbnailing a remote image.
 				_this.getFileHTTP(remoteImagePath, localImagePath, stream, callback);
 			} else { // we are thumbnailing an Object in our thumbnail S3 bucket.
 				_this.getFileS3(bucket, region, remoteImagePath, localImagePath, stream,extension, callback);
 			}
+			*/
+			_this.getFileS3(bucket, region, remoteImagePath, localImagePath, stream,extension, callback);
 		}); // close immediately, we do not use this file handle.
-		*/
+		
 	});
 };
 
@@ -101,8 +103,9 @@ Grabber.prototype.getFileS3 = function(bucket, region, remoteImagePath, localIma
 			stream.end();
 			return callback(Error('error retrieving from S3 stream is null.... '));
 		}
-		localImagePath = localImagePath+extension;
-		var writeSteam = fs.createWriteStream(localImagePath);
+		//localImagePath = localImagePath+extension;
+		var writeSteam = stream;
+		//fs.createWriteStream(localImagePath);
 		awsStream.pipe(writeSteam);
 		awsStream.on('end', function() {
 			_this.logger.info('write finished..', remoteImagePath, 'from s3 to local file', localImagePath);

--- a/lib/grabber.js
+++ b/lib/grabber.js
@@ -22,23 +22,29 @@ function Grabber() {
  */
 Grabber.prototype.download = function(bucket, region, remoteImagePath, callback) {
 	var _this = this,
-		extension = remoteImagePath.split('.').pop();
+		extension = "."+remoteImagePath.split('.').pop();
 
-	tmp.file({dir: config.get('tmpDir'), postfix: "." + extension}, function(err, localImagePath, fd) {
-
+	
+	tmp.file({dir: config.get('tmpDir'), postfix: ""}, function(err, localImagePath, fd) {
+		//_this.logger.info('downloading', remoteImagePath, 'from s3 to local file', localImagePath);
 		if (err) return callback(err);
-
+		//var stream = fs.createWriteStream(localImagePath, { flags: 'w', encoding: null, mode: 0666 });
+		var stream = null;
+		_this.getFileS3(bucket, region, remoteImagePath, localImagePath, stream,extension, callback);
+		/*
 		fs.close(fd, function() {
 			_this.logger.info('downloading', remoteImagePath, 'from s3 to local file', localImagePath);
 
 			var stream = fs.createWriteStream(localImagePath);
+			//var stream = null;
 
 			if (remoteImagePath.match(/https?:\/\//)) { // we are thumbnailing a remote image.
 				_this.getFileHTTP(remoteImagePath, localImagePath, stream, callback);
 			} else { // we are thumbnailing an Object in our thumbnail S3 bucket.
-				_this.getFileS3(bucket, region, remoteImagePath, localImagePath, stream, callback);
+				_this.getFileS3(bucket, region, remoteImagePath, localImagePath, stream,extension, callback);
 			}
 		}); // close immediately, we do not use this file handle.
+		*/
 	});
 };
 
@@ -50,7 +56,7 @@ Grabber.prototype.download = function(bucket, region, remoteImagePath, callback)
  * @param WriteStream stream The stream object for the local file
  * @param function callback The callback function
  */
-Grabber.prototype.getFileHTTP = function(remoteImagePath, localImagePath, stream, callback) {
+Grabber.prototype.getFileHTTP = function(remoteImagePath, localImagePath, stream,extension, callback) {
 	var _this = this,
 		protocol = remoteImagePath.match('https://') ? https : http,
 		req = protocol.get(remoteImagePath, function(res) {
@@ -88,7 +94,28 @@ Grabber.prototype.getFileHTTP = function(remoteImagePath, localImagePath, stream
  * @param WriteStream stream The stream object for the local file
  * @param function callback The callback function
  */
-Grabber.prototype.getFileS3 = function(bucket, region, remoteImagePath, localImagePath, stream, callback) {
+Grabber.prototype.getFileS3 = function(bucket, region, remoteImagePath, localImagePath, stream,extension, callback) {
+	var _this = this;
+	utils.s3(bucket, region).getFile(remoteImagePath,function(err,awsStream){
+		if (err || !awsStream){
+			stream.end();
+			return callback(Error('error retrieving from S3 stream is null.... '));
+		}
+		localImagePath = localImagePath+extension;
+		var writeSteam = fs.createWriteStream(localImagePath);
+		awsStream.pipe(writeSteam);
+		awsStream.on('end', function() {
+			_this.logger.info('write finished..', remoteImagePath, 'from s3 to local file', localImagePath);
+			writeSteam.end();
+			callback(null, localImagePath, null);
+		}).on('error', function(err) {
+			writeSteam.end();
+			callback(err);
+		});
+	});
+	
+}
+Grabber.prototype.getFileS3_OLD = function(bucket, region, remoteImagePath, localImagePath, stream, callback) {
 	var _this = this,
 		req = utils.s3(bucket, region).getFile(remoteImagePath, function(err, res) {
 

--- a/lib/grabber.js
+++ b/lib/grabber.js
@@ -26,12 +26,7 @@ Grabber.prototype.download = function(bucket, region, remoteImagePath, callback)
 
 	
 	tmp.file({dir: config.get('tmpDir'), postfix: extension}, function(err, localImagePath, fd) {
-		//_this.logger.info('downloading', remoteImagePath, 'from s3 to local file', localImagePath);
 		if (err) return callback(err);
-		//var stream = fs.createWriteStream(localImagePath, { flags: 'w', encoding: null, mode: 0666 });
-		//var stream = null;
-		//_this.getFileS3(bucket, region, remoteImagePath, localImagePath, stream,extension, callback);
-		
 		fs.close(fd, function() {
 			_this.logger.info('downloading', remoteImagePath, 'from s3 to local file', localImagePath);
 
@@ -44,7 +39,7 @@ Grabber.prototype.download = function(bucket, region, remoteImagePath, callback)
 				_this.getFileS3(bucket, region, remoteImagePath, localImagePath, stream,extension, callback);
 			}
 			*/
-			_this.getFileS3(bucket, region, remoteImagePath, localImagePath, stream,extension, callback);
+			_this.getFileS3(bucket, region, remoteImagePath, localImagePath, stream, callback);
 		}); // close immediately, we do not use this file handle.
 		
 	});
@@ -58,7 +53,7 @@ Grabber.prototype.download = function(bucket, region, remoteImagePath, callback)
  * @param WriteStream stream The stream object for the local file
  * @param function callback The callback function
  */
-Grabber.prototype.getFileHTTP = function(remoteImagePath, localImagePath, stream,extension, callback) {
+Grabber.prototype.getFileHTTP = function(remoteImagePath, localImagePath, stream, callback) {
 	var _this = this,
 		protocol = remoteImagePath.match('https://') ? https : http,
 		req = protocol.get(remoteImagePath, function(res) {
@@ -96,16 +91,13 @@ Grabber.prototype.getFileHTTP = function(remoteImagePath, localImagePath, stream
  * @param WriteStream stream The stream object for the local file
  * @param function callback The callback function
  */
-Grabber.prototype.getFileS3 = function(bucket, region, remoteImagePath, localImagePath, stream,extension, callback) {
+Grabber.prototype.getFileS3 = function(bucket, region, remoteImagePath, localImagePath, writeSteam, callback) {
 	var _this = this;
 	utils.s3(bucket, region).getFile(remoteImagePath,function(err,awsStream){
 		if (err || !awsStream){
 			stream.end();
 			return callback(Error('error retrieving from S3 stream is null.... '));
 		}
-		//localImagePath = localImagePath+extension;
-		var writeSteam = stream;
-		//fs.createWriteStream(localImagePath);
 		awsStream.pipe(writeSteam);
 		awsStream.on('end', function() {
 			_this.logger.info('write finished..', remoteImagePath, 'from s3 to local file', localImagePath);

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,15 +1,15 @@
 var config = require('./config').Config;
 
 exports.info = function() {
-  if (config.get('logLevel') === 'info') console.info.apply(this, arguments)
+  if (config.get('logLevel') === 'info') console.info.apply(this, [Date.now()].concat(arguments))
 }
 
 exports.warn = function() {
   var logLevel = config.get('logLevel');
 
-  if (logLevel === 'info' || logLevel === 'warn') console.warn.apply(this, arguments)
+  if (logLevel === 'info' || logLevel === 'warn') console.warn.apply(this, [Date.now()].concat(arguments))
 }
 
 exports.error = function() {
-  if (config.get('logLevel') !== 'silent') console.warn.apply(this, arguments)
+  if (config.get('logLevel') !== 'silent') console.warn.apply(this, [Date.now()].concat(arguments))
 }

--- a/lib/s3helper.js
+++ b/lib/s3helper.js
@@ -1,0 +1,85 @@
+var AWS = require('aws-sdk'),
+	fs = require('fs');
+  
+/**
+ * Initialize the s3helper
+ *
+ * 
+ */
+function S3helper() {
+	this.logger = require('./logger');
+}
+
+/**
+ * Initialize a `Client` with the given `options`.
+ *
+ * Required:
+ *
+ *  - `key`     amazon api key
+ *  - `secret`  amazon secret
+ *  - `bucket`  bucket name string, ex: "learnboost"
+ *
+ * @param {Object} options
+ * @api public
+ */
+
+var Client = module.exports = exports = function Client(options) {
+  if (!options.key) throw new Error('aws "key" required');
+  if (!options.secret) throw new Error('aws "secret" required');
+  if (!options.bucket) throw new Error('aws "bucket" required');
+  if (!options.region) throw new Error('aws "region" required');
+
+  if (!options.endpoint) {
+    if (!options.region || options.region === 'us-standard' || options.region === 'us-east-1') {
+      options.endpoint = 's3.amazonaws.com';
+      options.region = 'us-standard';
+    } else if(options.region === 'cn-north-1'){
+	  options.endpoint = 's3.cn-north-1.amazonaws.com.cn'; 
+    } 
+    else {
+      options.endpoint = 's3-' + options.region + '.amazonaws.com';
+    }
+  } else {
+    options.region = undefined;
+  }
+  
+  AWS.config.update({accessKeyId: options.key, secretAccessKey: options.secret});
+  AWS.config.update({region: options.region});
+  var conn =  {region: options.region };
+  if(options.region === 'cn-north-1'){
+	  conn.signatureVersion = 'v4';
+  }
+  this.s3 = new AWS.S3(conn);
+  this.bucket = options.bucket;
+};
+
+
+Client.prototype.getFile = function(remoteImagePath, fn){
+  var params = {Bucket: this.bucket, Key: remoteImagePath};
+  var awsStream = this.s3.getObject(params).createReadStream();
+  fn(null,awsStream);
+};
+
+Client.prototype.putFile = function(source, destination, fn){
+  var _this = this;
+  var fileStream = fs.createReadStream(source);
+  fileStream.on('error', function (err) {
+  	if (err) { fn(err,null); }
+  	return;
+  });
+  fileStream.on('open', function () {
+  	_this.s3.putObject({
+    		Bucket: _this.bucket,
+			Key: destination,
+			Body: fileStream
+  		}, function (err,data) {
+    		fn(err,data);
+  		});
+  });
+  
+};
+
+exports.createClient = function(options){
+  return new Client(options);
+};
+

--- a/lib/s3helper.js
+++ b/lib/s3helper.js
@@ -45,11 +45,8 @@ var Client = module.exports = exports = function Client(options) {
   
   AWS.config.update({accessKeyId: options.key, secretAccessKey: options.secret});
   AWS.config.update({region: options.region});
-  var conn =  {region: options.region };
-  if(options.region === 'cn-north-1'){
-	  conn.signatureVersion = 'v4';
-  }
-  this.s3 = new AWS.S3(conn);
+
+  this.s3 = new AWS.S3({signatureVersion: 'v4',region: options.region });
   this.bucket = options.bucket;
 };
 

--- a/lib/saver.js
+++ b/lib/saver.js
@@ -25,7 +25,7 @@ Saver.prototype.save = function(bucket, region, source, destination, metadata, c
 	if (typeof callback === 'undefined') {
 		callback = function() {};
 	}
-
+	/*
 	var headers = {
 		'x-amz-acl': config.get('s3Acl'),
 		'x-amz-storage-class': config.get('s3StorageClass')
@@ -36,23 +36,13 @@ Saver.prototype.save = function(bucket, region, source, destination, metadata, c
 	if (destination.match(/https?:\/\//)) {
 		destination = this.destinationFromURL(destination);
 	}
-
-	utils.s3(bucket, region).putFile(source, destination, headers, function(err, res) {
-		// if the region or bucket is wrong, this is reflected in a 301.
-		if (res && res.statusCode !== 200) {
-			return callback(Error('upload failure status = ' + res.statusCode));
-		}
+	*/
+	utils.s3(bucket, region).putFile(source, destination, function(err, res) {
+		
 		if (err) return callback(err);
 
-		res.on('error', function(err) {
-			callback(err);
-		});
-
-		res.on('end', function() {
-			_this.logger.info('saved ' + source + ' to ' + destination);
-			callback();
-		})
-		res.resume();
+		_this.logger.info('saved ' + source + ' to ' + destination);
+		callback();
 	});
 };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,4 @@
-var knox = require('knox'),
+var s3helper = require('./s3helper'),
   client = null,
   config = require('./config').Config;
 
@@ -7,6 +7,8 @@ var knox = require('knox'),
 *
 * @param string bucket S3 bucket to connect to.
 */
+
+
 exports.s3 = function(_bucket, _region) {
   var bucket = _bucket || config.get('s3Bucket'),
     region = _region || config.get('awsRegion');
@@ -15,10 +17,12 @@ exports.s3 = function(_bucket, _region) {
 	if (region == 'us-east-1') region = 'us-standard';
 
   // cache the most recently used client.
+
+  
   if (client && bucket === client.bucket && region === client.region) {
     return client;
   } else {
-    client = knox.createClient({
+    client = s3helper.createClient({
       key: config.get('awsKey'),
       secret: config.get('awsSecret'),
       bucket: bucket,

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -43,7 +43,7 @@ Worker.prototype.start = function() {
 Worker.prototype._processSQSMessage = function() {
 	var _this = this;
 
-	this.logger.info('wait for message on ' + config.get('sqsQueue'));
+	//this.logger.info('wait for message on ' + config.get('sqsQueue'));
 
 	this.sqs.receiveMessage( { QueueUrl: config.get('sqsQueueUrl'), MaxNumberOfMessages: 1 }, function (err, job) {
 		if (err) {


### PR DESCRIPTION
1.Support signature version 4 
2.Removed knox and use AWS SDK directly

Didn't support HTTP right now, maybe need call "putBucketWebsite".
But I can't do it in China, as we can't access S3 through http before the domain name has been acquired the ICP license. 

So, it can't pass the test-client.js