### PR TITLE
Corrected typo in worker preventing custom 'prefix' from being used.

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -117,7 +117,7 @@ Worker.prototype._runJob = function(handle, job, callback) {
 	if (job.original) job.resources = [job.original];
 
 	// if the prefix is missing, default to the filename.
-	if (!job.perfix) job.prefix = job.resources[0].split('.').slice(0, -1).join('.');
+	if (!job.prefix) job.prefix = job.resources[0].split('.').slice(0, -1).join('.');
 
 	var _this = this;
 


### PR DESCRIPTION
Bugfix: Allows custom prefixes to be used once the job has been received.