### PR TITLE
Custom logger support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ Thumbd requires the following environment variables to be set:
 
 When running locally, I set these environment variables in a .env file and execute thumbd using Foreman.
 
+Additionally, the following environment variable can be set to use a custom logger:
+
+**LOGGER_FILE** the path to a javascript file that exports the `info`, `warn` and `error` methods.
+
 Server
 ------
 

--- a/bin/thumbd.js
+++ b/bin/thumbd.js
@@ -69,6 +69,10 @@ var yargs = require('yargs')
       alias: 'log_level',
       description: 'set log level (info|warn|error|silent)'
     })
+    .option('c', {
+      alias: 'custom_logger',
+      description: 'path to custom logger'
+    })
     .usage('Usage: $0 <command>')
     .command('server', 'start a thumbnailing server')
     .command('thumbnail', 'given S3 path and description, thumbnail an image')
@@ -93,6 +97,7 @@ var serverOpts = {
   sqs_queue: 'sqsQueue',
   tmp_dir: 'tmpDir',
   log_level: 'logLevel',
+  custom_logger: 'logger',
   profile: 'profile'
 }
 var thumbnailOpts = {
@@ -103,14 +108,15 @@ var thumbnailOpts = {
   remote_image: 'remoteImage',
   sqs_queue: 'sqsQueue',
   bucket: 's3Bucket',
-  log_level: 'logLevel'
+  log_level: 'logLevel',
+  custom_logger: 'logger'
 }
 var ndm = require('ndm')('thumbd')
 var opts = null
 
 // make console output nicer for missing arguments.
 process.on('uncaughtException', function (err) {
-  var logger = require('../lib/logger')
+  var logger = require(config.get('logger'))
   logger.error(err.message)
 })
 
@@ -162,7 +168,7 @@ switch (mode) {
     config.extend(opts)
 
     var client = new thumbd.Client()
-    var logger = require('../lib/logger')
+    var logger = require(config.get('logger'))
 
     client.thumbnail(
       opts.remoteImage,

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,4 +1,5 @@
 var _ = require('lodash')
+var path = require('path')
 
 exports.Config = {
   config: {
@@ -12,6 +13,7 @@ exports.Config = {
     s3StorageClass: (process.env.S3_STORAGE_CLASS || 'STANDARD'),
     sqsQueue: process.env.SQS_QUEUE,
     tmpDir: (process.env.TMP_DIR || '/tmp'),
+    logger: (process.env.LOGGER_FILE || path.resolve(path.join(__dirname, './logger'))),
     logLevel: (process.env.LOG_LEVEL || 'info'),
     profile: !!process.env.PROFILE,
     metaPrefix: (process.env.META_PREFIX || 'x-amz-meta-'),

--- a/lib/grabber.js
+++ b/lib/grabber.js
@@ -11,7 +11,7 @@ var config = require('./config').Config
  * @param object s3 The S3 client
  */
 function Grabber () {
-  this.logger = require('./logger')
+  this.logger = require(config.get('logger'))
 }
 
 /**

--- a/lib/saver.js
+++ b/lib/saver.js
@@ -9,7 +9,7 @@ var config = require('./config').Config
  * @param object s3 The S3 client
  */
 function Saver () {
-  this.logger = require('./logger')
+  this.logger = require(config.get('logger'))
 }
 
 /**

--- a/lib/thumbnailer.js
+++ b/lib/thumbnailer.js
@@ -12,7 +12,7 @@ function Thumbnailer (opts) {
   // perform dependency injection.
   _.extend(this, {
     tmp: require('tmp'),
-    logger: require('./logger')
+    logger: require(config.get('logger'))
   }, opts)
 }
 

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -15,7 +15,7 @@ function Worker (opts) {
   _.extend(this, {
     grabber: null,
     saver: null,
-    logger: require('./logger')
+    logger: require(config.get('logger'))
   }, opts)
 
   this.sqs = new aws.SQS({

--- a/test/fixtures/customLogger.js
+++ b/test/fixtures/customLogger.js
@@ -1,0 +1,9 @@
+var lastLog = ''
+
+exports.info = exports.warn = exports.error = function () {
+  lastLog = Array.prototype.join.call(arguments, ' ')
+}
+
+exports.__getLastLog = function () {
+  return lastLog
+}

--- a/test/test-logger.js
+++ b/test/test-logger.js
@@ -1,0 +1,29 @@
+/* global describe, it */
+
+var assert = require('assert')
+var config = require('../lib').Config
+var path = require('path')
+var customLogger = require('./fixtures/customLogger')
+
+describe('Logger', function () {
+  describe('custom logger', function () {
+    var defaultLogger = config.get('logger')
+    config.set('logger', path.resolve(path.join(__dirname, './fixtures/customLogger')))
+    var logger = require(config.get('logger'))
+
+    it('should call the custom logger', function () {
+      assert.equal(customLogger.__getLastLog(), '')
+
+      logger.info('test 123')
+      assert.equal(customLogger.__getLastLog(), 'test 123')
+
+      logger.warn('test abc')
+      assert.equal(customLogger.__getLastLog(), 'test abc')
+
+      logger.error('test', 'abc', '123')
+      assert.equal(customLogger.__getLastLog(), 'test abc 123')
+    })
+
+    config.set('logger', defaultLogger)
+  })
+})


### PR DESCRIPTION
As described in #102.

Tests are rudimentary, given some time I'd like a cleaner mock approach. Don't hesitate to point stuff out! The rationale is that we use a custom Sentry logger and would like to be aware of problems with our thumbd queue and only logging to the console won't help in that regard.

Thanks