### PR TITLE
Preserve encryption headers when uploading thumbnails

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -17,7 +17,8 @@ exports.Config = {
     logLevel: (process.env.LOG_LEVEL || 'info'),
     profile: !!process.env.PROFILE,
     metaPrefix: (process.env.META_PREFIX || 'x-amz-meta-'),
-    keepMeta: (process.env.META || true)
+    keepMeta: (process.env.META || true),
+    keepEncryption: (process.env.ENCRYPTION || true)
   },
 
   /**

--- a/lib/grabber.js
+++ b/lib/grabber.js
@@ -124,13 +124,13 @@ Grabber.prototype.getFileS3 = function (bucket, region, remoteImagePath, localIm
   })
 }
 
-// copy any x-amz-meta prefixed headers to the
-// thumbnail image being created.
+// copy any x-amz-meta prefixed and x-amz-server-side-encryption headers
+// to the thumbnail image being created.
 Grabber.prototype.getMeta = function (res) {
   var metadata = {}
-  if (config.get('keepMeta')) {
+  if (config.get('keepMeta') || config.get('keepEncryption')) {
     for (var prop in res.headers) {
-      if (prop.slice(0, 11) === config.get('metaPrefix')) {
+      if (prop === 'x-amz-server-side-encryption' || prop.slice(0, 11) === config.get('metaPrefix')) {
         metadata[prop] = res.headers[prop]
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbd",
-  "version": "2.18.0",
+  "version": "2.19.0",
   "directories": {
     "bin": "./bin",
     "data": "./data",

--- a/test/test-grabber.js
+++ b/test/test-grabber.js
@@ -27,6 +27,22 @@ describe('Grabber', function () {
         return done(err)
       })
     })
+
+    it('should call save with x-amz-server-side-encryption returned by AWS', function (done) {
+      var grabber = new Grabber()
+      var mockDownload = nock('https://my-bucket.s3.amazonaws.com')
+        .defaultReplyHeaders({
+          'x-amz-server-side-encryption': 'AES256'
+        })
+        .get('/foo/awesome.jpg')
+        .reply(200, 'abc123')
+
+      grabber.download('my-bucket', 'us-east-1', '/foo/awesome.jpg', function (err, data, headers) {
+        mockDownload.done()
+        assert.equal(headers['x-amz-server-side-encryption'], 'AES256')
+        return done(err)
+      })
+    })
   })
 
 })


### PR DESCRIPTION
When the file is uploaded with the Server-Side Encryption enabled on AWS, the generated thumbnails were uploaded unencrypted. 