### PR TITLE
Handle no extension file for grabber.download

### DIFF
--- a/lib/grabber.js
+++ b/lib/grabber.js
@@ -22,7 +22,9 @@ function Grabber () {
  */
 Grabber.prototype.download = function (bucket, region, remoteImagePath, callback) {
   var _this = this
-  var extension = remoteImagePath.split('.').pop()
+
+  // Handle no extension file, replace all `/` with `_`
+  var extension = remoteImagePath.replace(/\//g, '_').split('.').pop()
 
   tmp.file({dir: config.get('tmpDir'), postfix: '.' + extension}, function (err, localImagePath, fd) {
     if (err) return callback(err)


### PR DESCRIPTION
Currently I don't set extension to file (ex: `photo/image1`), it will broken download of grabber: 

```
ENOENT: no such file or directory, open '/tmp/tmp-38316J6zQx25w66CK.photo/image1'
```

Or `photo.s/image1` will get `s/image1` as a extension, so I think we should avoid `/`.
