### PR TITLE
Ensure requestTimeout is number

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -7,7 +7,7 @@ exports.Config = {
     awsRegion: process.env.AWS_REGION || 'us-east-1',
     awsSecret: process.env.AWS_SECRET,
     convertCommand: (process.env.CONVERT_COMMAND || 'convert'),
-    requestTimeout: (process.env.REQUEST_TIMEOUT || 15000),
+    requestTimeout: Number(process.env.REQUEST_TIMEOUT || 15000),
     s3Acl: (process.env.S3_ACL || 'private'),
     s3Bucket: process.env.BUCKET,
     s3StorageClass: (process.env.S3_STORAGE_CLASS || 'STANDARD'),


### PR DESCRIPTION
Avoid `TypeError: "msecs" argument must be a number` from grabber if we set `REQUEST_TIMEOUT` env.
